### PR TITLE
exefs2elf: Use subprocess.run instead of system() 

### DIFF
--- a/tools/exefs2elf.py
+++ b/tools/exefs2elf.py
@@ -18,14 +18,14 @@ BASEROMDIR = 'baserom/'
 WORKDIR = BASEROMDIR + 'workdir/'
 
 def run(cmd):
-	os.system(cmd)
+    os.system(cmd)
 
 def writefile(path, s):
-	with open(path, "wb") as f:
-		f.write(str(s))
+    with open(path, "wb") as f:
+        f.write(str(s))
 
 with open(BASEROMDIR + "exheader.bin", "rb") as f:
-	exh = f.read(64)
+    exh = f.read(64)
 
 (textBase, textPages, roPages, rwPages, bssSize) = struct.unpack('16x ii 12x i 12x i 4x i', exh)
 textSize = textPages * 0x1000
@@ -40,40 +40,40 @@ bssSize  = (int(bssSize / 0x1000) + 1) * 0x1000
 # print("bssSize:  {:08x}".format(bssSize))
 
 if (textBase != 0x100000):
-	print('WARNING: textBase mismatch, might be an encrypted exheader file.')
+    print('WARNING: textBase mismatch, might be an encrypted exheader file.')
 
 # run('mkdir ' + WORKDIR)
 
 exefsPath = BASEROMDIR + '/exefs/'
 with open(exefsPath + 'code.bin', "rb") as f:
-	text = f.read(textSize)
-	ro = f.read(roSize)
-	rw = f.read(rwSize)
-	
+    text = f.read(textSize)
+    ro = f.read(roSize)
+    rw = f.read(rwSize)
+    
 with open('tools/e2elf.ld', 'r') as f:
-	ldscript = f.read()
+    ldscript = f.read()
 ldscript = ldscript.replace('%memorigin%', str(textBase))
 ldscript = ldscript.replace('%bsssize%', str(bssSize))
 
 with open(WORKDIR + 'e2elf.ld', 'w') as ldfile:
-	ldfile.write(ldscript)
+    ldfile.write(ldscript)
 # writefile(WORKDIR + 'e2elf.ld', ldscript)
 
 with open(WORKDIR + 'text.bin', 'wb') as textfile:
-	textfile.write(text)
+    textfile.write(text)
 with open(WORKDIR + 'ro.bin', 'wb') as rofile:
-	rofile.write(ro)
+    rofile.write(ro)
 with open(WORKDIR + 'rw.bin', 'wb') as datafile:
-	datafile.write(rw)
+    datafile.write(rw)
 # writefile(WORKDIR + 'text.bin', text)
 # writefile(WORKDIR + 'ro.bin', ro)
 # writefile(WORKDIR + 'rw.bin', rw)
 
 objfiles = ''
 for i in (('text', 'text'), ('ro', 'rodata'), ('rw', 'data')):
-	desc, sec_name = i
-	run('{0} -I binary -O elf32-littlearm --rename-section .data=.{1} {2}{3}.bin {2}{3}.o'
+    desc, sec_name = i
+    run('{0} -I binary -O elf32-littlearm --rename-section .data=.{1} {2}{3}.bin {2}{3}.o'
         .format(OC, sec_name, WORKDIR, desc))
-	objfiles += '{0}{1}.o '.format(WORKDIR, desc)
-	
+    objfiles += '{0}{1}.o '.format(WORKDIR, desc)
+    
 run(LD + ' --accept-unknown-input-arch -T ' + WORKDIR + 'e2elf.ld -o ' + BASEROMDIR + '/baserom.elf ' + objfiles)

--- a/tools/exefs2elf.py
+++ b/tools/exefs2elf.py
@@ -1,7 +1,8 @@
 # convert exefs to elf
-import sys
 import os
 import struct
+import subprocess
+import sys
 
 if 'DEVKITARM' not in os.environ:
     print('DEVKITARM environment variable is not set!')
@@ -16,13 +17,6 @@ LD = DEVKITARM + "/bin/arm-none-eabi-ld"
 
 BASEROMDIR = 'baserom/'
 WORKDIR = BASEROMDIR + 'workdir/'
-
-def run(cmd):
-    os.system(cmd)
-
-def writefile(path, s):
-    with open(path, "wb") as f:
-        f.write(str(s))
 
 with open(BASEROMDIR + "exheader.bin", "rb") as f:
     exh = f.read(64)
@@ -42,14 +36,12 @@ bssSize  = (int(bssSize / 0x1000) + 1) * 0x1000
 if (textBase != 0x100000):
     print('WARNING: textBase mismatch, might be an encrypted exheader file.')
 
-# run('mkdir ' + WORKDIR)
-
 exefsPath = BASEROMDIR + '/exefs/'
 with open(exefsPath + 'code.bin', "rb") as f:
     text = f.read(textSize)
     ro = f.read(roSize)
     rw = f.read(rwSize)
-    
+
 with open('tools/e2elf.ld', 'r') as f:
     ldscript = f.read()
 ldscript = ldscript.replace('%memorigin%', str(textBase))
@@ -57,7 +49,6 @@ ldscript = ldscript.replace('%bsssize%', str(bssSize))
 
 with open(WORKDIR + 'e2elf.ld', 'w') as ldfile:
     ldfile.write(ldscript)
-# writefile(WORKDIR + 'e2elf.ld', ldscript)
 
 with open(WORKDIR + 'text.bin', 'wb') as textfile:
     textfile.write(text)
@@ -65,15 +56,12 @@ with open(WORKDIR + 'ro.bin', 'wb') as rofile:
     rofile.write(ro)
 with open(WORKDIR + 'rw.bin', 'wb') as datafile:
     datafile.write(rw)
-# writefile(WORKDIR + 'text.bin', text)
-# writefile(WORKDIR + 'ro.bin', ro)
-# writefile(WORKDIR + 'rw.bin', rw)
 
-objfiles = ''
-for i in (('text', 'text'), ('ro', 'rodata'), ('rw', 'data')):
-    desc, sec_name = i
-    run('{0} -I binary -O elf32-littlearm --rename-section .data=.{1} {2}{3}.bin {2}{3}.o'
-        .format(OC, sec_name, WORKDIR, desc))
-    objfiles += '{0}{1}.o '.format(WORKDIR, desc)
-    
-run(LD + ' --accept-unknown-input-arch -T ' + WORKDIR + 'e2elf.ld -o ' + BASEROMDIR + '/baserom.elf ' + objfiles)
+objfiles = []
+for pair in (('text', 'text'), ('ro', 'rodata'), ('rw', 'data')):
+    desc, sec_name = pair
+    obj_name = f'{WORKDIR}{desc}.o'
+    subprocess.run([OC, '-I', 'binary', '-O', 'elf32-littlearm', '--rename-section', f'.data=.{sec_name}', f'{WORKDIR}{desc}.bin', obj_name])
+    objfiles.append(obj_name)
+
+subprocess.run([LD, '--accept-unknown-input-arch', '-T', f'{WORKDIR}e2elf.ld', '-o', f'{BASEROMDIR}baserom.elf'] + objfiles)


### PR DESCRIPTION
Allows the arguments to be specified individually without any string spacing. subprocess is also recommended over system() for running commands. It also doesn't create a subshell